### PR TITLE
ci: re-enable windows build with static vcpkg dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,9 @@ jobs:
           - platform: 'ubuntu-24.04'   # glibc 2.39 — required by ORT prebuilt binaries
             args: ''
             rust_targets: ''
-          # Windows removed: mingw-w64-x86_64-gexiv2 does not exist in MSYS2.
-          # Add back once gexiv2 is available via vcpkg + x86_64-pc-windows-msvc target.
+          - platform: 'windows-latest'
+            args: ''
+            rust_targets: ''
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -85,6 +86,25 @@ jobs:
         if: startsWith(matrix.platform, 'macos')
         run: brew install gexiv2 pkg-config libffi
 
+      # ── Windows ──────────────────────────────────────────────────────────────
+      - name: Cache vcpkg binaries
+        if: startsWith(matrix.platform, 'windows')
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/vcpkg-cache
+          key: ${{ runner.os }}-vcpkg-${{ hashFiles('.github/workflows/publish.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-
+
+      - name: Install Dependencies (Windows)
+        if: startsWith(matrix.platform, 'windows')
+        env:
+          VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/vcpkg-cache,readwrite"
+        run: |
+          vcpkg install gexiv2:x64-windows-static-md
+          vcpkg install pkgconf:x64-windows
+        shell: pwsh
+
       # ── Shared ───────────────────────────────────────────────────────────────
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -138,6 +158,15 @@ jobs:
           echo "PKG_CONFIG_PATH=${BREW_PKGCONFIG}" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH_aarch64_apple_darwin=${BREW_PKGCONFIG}" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH_x86_64_apple_darwin=${BREW_PKGCONFIG}" >> $GITHUB_ENV
+
+      - name: Configure Windows Environment
+        if: startsWith(matrix.platform, 'windows')
+        run: |
+          $vcpkgRoot = $env:VCPKG_INSTALLATION_ROOT
+          echo "PKG_CONFIG=$vcpkgRoot\installed\x64-windows\tools\pkgconf\pkgconf.exe" >> $env:GITHUB_ENV
+          echo "PKG_CONFIG_PATH=$vcpkgRoot\installed\x64-windows-static-md\lib\pkgconfig" >> $env:GITHUB_ENV
+          echo "PKG_CONFIG_ALL_STATIC=1" >> $env:GITHUB_ENV
+        shell: pwsh
 
       - name: Cache ONNX model
         uses: actions/cache@v4


### PR DESCRIPTION
Re-enables windows build using static vcpkg dependencies for gexiv2 and pkgconf.