### PR TITLE
fix(linux): render UI correctly in AppImage (CSP nonce + SVG sizing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,14 @@ jobs:
             libxdo-dev \
             libssl-dev \
             libayatana-appindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-libav \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            patchelf
 
       # ── macOS ────────────────────────────────────────────────────────────────
       - name: Install Dependencies (macOS)

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ requirements-dev.txt
 .factorypath
 .act-secrets
 .pnpm-store/
+
+# Claude Code local agent memory/config
+.claude/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-app",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tauri-app",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.imagelabelia.app",
   "build": {
     "beforeDevCommand": "npm run start",
@@ -19,6 +19,7 @@
     ],
     "security": {
       "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src ipc: http://ipc.localhost",
+      "dangerousDisableAssetCspModification": ["style-src"],
       "assetProtocol": {
         "enable": true,
         "scope": {
@@ -30,6 +31,11 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": true
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/assets/tauri.svg
+++ b/src/assets/tauri.svg
@@ -2,8 +2,8 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="320mm"
-   height="320mm"
+   width="320"
+   height="320"
    viewBox="0 0 320 320"
    version="1.1"
    id="svg1"


### PR DESCRIPTION
## Problem
The Linux AppImage launched but rendered **only a giant logo with no layout** — the long-standing Linux render bug.

## Root cause
Not a WebKitGTK/Wayland/Intel issue (ruled out — dev and prod bundles both render fine in the same engine). The real cause:

1. Tauri injects a per-load `'nonce-…'` into the CSP **`style-src`** at runtime (`__TAURI_STYLE_NONCE__`).
2. Per the CSP spec, a nonce in `style-src` makes the browser **ignore `'unsafe-inline'`**.
3. Angular injects every component's CSS at runtime via `createElement("style")` — those `<style>` tags carry no nonce, so **WebKitGTK blocked all component CSS**.
4. With no component CSS, `.brand-logo { width: 42px }` never applied and the `<img>` fell back to the SVG's `320mm` (~1210px) intrinsic size → giant logo, no layout.

## Fix
- **`tauri.conf.json`**: `dangerousDisableAssetCspModification: ["style-src"]` — Tauri leaves `style-src` verbatim (keeps `'unsafe-inline'`, no nonce) while still nonce-protecting `script-src`.
- **`tauri.svg`**: `320mm` → `320` intrinsic size (defense in depth, so the logo can never balloon again).
- Carries over the GStreamer media-framework bundling + build deps (fixes the earlier `appsink` error) and bumps version to **0.1.3**.

## Verification
Rebuilt the AppImage with the real CSP applied and launched it — the full UI now renders correctly (proper-size logo, header, Folders/Details panels, breadcrumb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)