### PR TITLE
ci: faster builds — drop rpm, add Swatinem/rust-cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,16 +52,10 @@ jobs:
           targets: ${{ matrix.rust_targets }}
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            src-tauri/target
-          key: ${{ runner.os }}-${{ matrix.rust_targets }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.rust_targets }}-cargo-
-            ${{ runner.os }}-cargo-
+          workspaces: src-tauri
+          key: ${{ matrix.rust_targets }}
 
       # ── Linux ────────────────────────────────────────────────────────────────
       - name: Install Dependencies (Linux)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,7 +30,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["deb", "appimage", "app", "dmg", "nsis", "msi"],
     "linux": {
       "appimage": {
         "bundleMediaFramework": true


### PR DESCRIPTION
## Why
Tagged release builds were slow (~30–45 min on Linux). Two causes:

1. **Cold Rust compiles** — the `actions/cache` step over `src-tauri/target` was effectively a no-op (restored nothing), so every build recompiled the whole dependency tree (`ort`/ONNX, Tauri, image crates) in release mode from scratch.
2. **`bundle.targets: "all"`** built `.deb` + `.rpm` + `.AppImage` on Linux, each compressing the large payload (binary + bundled ONNX model). `.rpm` is the slow compressor and only serves Fedora/RHEL.

## Changes
- **Drop `rpm`** from bundle targets (explicit list, otherwise identical to `all` for mac/windows). `.deb` already gives a proper *installed* experience on Debian/Ubuntu (apps menu, icon, `apt remove`); `.AppImage` stays as the portable option.
- **Swap `actions/cache` → `Swatinem/rust-cache`** — purpose-built for cargo, reliably caches the registry + compiled deps per workspace/target. Subsequent builds reuse deps instead of recompiling from scratch.

## Notes
- Separate from the v0.1.3 render fix; CI/config only, no app code, no version bump.
- Unrelated pre-existing issue: macOS `bundle_dmg.sh` is flaky on GitHub runners (failed on v0.1.3 at the DMG step *after* a successful compile). Can be addressed separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)